### PR TITLE
Fixes problem that curl fails to get universe.scm

### DIFF
--- a/src/spheres/spheres.scm
+++ b/src/spheres/spheres.scm
@@ -134,7 +134,7 @@ end-help-string
   (let* ((curl-process (open-process
                         (list
                          path: "curl"
-                         arguments: '("https://raw.github.com/alvatar/spheres/master/universe.scm"))))
+                         arguments: '("https://raw.githubusercontent.com/alvatar/spheres/master/universe.scm"))))
          (index (read-all curl-process))
          (results '()))
     (close-port curl-process)


### PR DESCRIPTION
Curl doesn't follow HTTP redirects (HTTP 301) from "https://raw.github.com/alvatar/spheres/master/universe.scm" to "https://raw.githubusercontent.com/alvatar/spheres/master/universe.scm".
